### PR TITLE
feat: Add support Message attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ go install github.com/k6io/xk6/cmd/xk6@latest
 export CGO_ENABLED=1
 ```
 ```shell
-xk6 build --with github.com/adibaulia/xk6-pubsub@latest
+xk6 build --with github.com/olvod/xk6-pubsub@latest
 ```
 
 xk6 build --with github.com/k6io/xk6-redis="/Users/avpretty/pr/xk6-pubsub"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ go install github.com/k6io/xk6/cmd/xk6@latest
 export CGO_ENABLED=1
 ```
 ```shell
-xk6 build --with github.com/olvod/xk6-pubsub@latest
+xk6 build --with github.com/adibaulia/xk6-pubsub@latest
 ```
 
 xk6 build --with github.com/k6io/xk6-redis="/Users/avpretty/pr/xk6-pubsub"

--- a/example.js
+++ b/example.js
@@ -15,7 +15,7 @@ export default function () {
         trace: true,
         doNotCreateTopicIfMissing: false
     });
-    let error = pubsub.publish(client, 'topic_name', 'message data');
+    let error = pubsub.publish(client, 'topic_name', 'message data', {key:"value",key2:"value2"});
 
     check(error, {
         "is sent": err => err === null

--- a/example.js
+++ b/example.js
@@ -1,4 +1,4 @@
-import {check} from 'k6';
+import { check } from 'k6';
 import pubsub from 'k6/x/pubsub';
 
 export default function () {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/olvod/xk6-pubsub
+module github.com/adibaulia/xk6-pubsub
 
 go 1.15
 
@@ -7,4 +7,5 @@ require (
 	github.com/ThreeDotsLabs/watermill-googlecloud v1.0.6
 	github.com/mitchellh/mapstructure v1.1.2
 	go.k6.io/k6 v0.32.0
+	google.golang.org/api v0.30.0
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/adibaulia/xk6-pubsub
+module github.com/olvod/xk6-pubsub
 
 go 1.15
 

--- a/pubsub.go
+++ b/pubsub.go
@@ -76,7 +76,7 @@ func (ps *PubSub) Publisher(config map[string]interface{}) *googlecloud.Publishe
 // Publish publishes a message to the provided topic using provided
 // googlecloud.Publisher. The msg value must be passed as string
 // and will be converted to bytes sequence before publishing.
-func (ps *PubSub) Publish(ctx context.Context, p *googlecloud.Publisher, topic, msg string) error {
+func (ps *PubSub) Publish(ctx context.Context, p *googlecloud.Publisher, topic, msg string, attributes map[string]string) error {
 	state := lib.GetState(ctx)
 
 	if state == nil {
@@ -85,9 +85,11 @@ func (ps *PubSub) Publish(ctx context.Context, p *googlecloud.Publisher, topic, 
 		return err
 	}
 
+	m := message.NewMessage(watermill.NewShortUUID(), []byte(msg))
+	m.Metadata = attributes
 	err := p.Publish(
 		topic,
-		message.NewMessage(watermill.NewShortUUID(), []byte(msg)),
+		m,
 	)
 
 	if err != nil {


### PR DESCRIPTION
I adjust some code to support Message attributes of Google Cloud Pub/Sub when publishing the message payload like this screenshoot 

![image](https://github.com/olvod/xk6-pubsub/assets/28526773/0e9c560b-c3d6-4a7e-a34a-bef286c7df32)
